### PR TITLE
Use lazy account slot initialization

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
@@ -206,7 +206,7 @@ public class ApplicationLoader extends Application {
                     }
 
                     boolean isSlow = isConnectionSlow();
-                    for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                    for (int a : UserConfig.getActivatedAccounts()) {
                         ConnectionsManager.getInstance(a).checkConnection();
                         FileLoader.getInstance(a).onNetworkChanged(isSlow);
                     }
@@ -239,18 +239,18 @@ public class ApplicationLoader extends Application {
 
         SharedConfig.loadConfig();
         SharedPrefsHelper.init(applicationContext);
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) { //TODO improve account
-            UserConfig.getInstance(a).loadConfig();
-            MessagesController.getInstance(a);
-            if (a == 0) {
-                SharedConfig.pushStringStatus = "__FIREBASE_GENERATING_SINCE_" + ConnectionsManager.getInstance(a).getCurrentTime() + "__";
+        for (int account : UserConfig.getActivatedAccounts()) {
+            UserConfig.getInstance(account).loadConfig();
+            MessagesController.getInstance(account);
+            if (account == UserConfig.selectedAccount) {
+                SharedConfig.pushStringStatus = "__FIREBASE_GENERATING_SINCE_" + ConnectionsManager.getInstance(account).getCurrentTime() + "__";
             } else {
-                ConnectionsManager.getInstance(a);
+                ConnectionsManager.getInstance(account);
             }
-            TLRPC.User user = UserConfig.getInstance(a).getCurrentUser();
+            TLRPC.User user = UserConfig.getInstance(account).getCurrentUser();
             if (user != null) {
-                MessagesController.getInstance(a).putUser(user, true);
-                SendMessagesHelper.getInstance(a).checkUnsentMessages();
+                MessagesController.getInstance(account).putUser(user, true);
+                SendMessagesHelper.getInstance(account).checkUnsentMessages();
             }
         }
 
@@ -261,9 +261,9 @@ public class ApplicationLoader extends Application {
         }
 
         MediaController.getInstance();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) { //TODO improve account
-            ContactsController.getInstance(a).checkAppAccount();
-            DownloadController.getInstance(a);
+        for (int account : UserConfig.getActivatedAccounts()) {
+            ContactsController.getInstance(account).checkAppAccount();
+            DownloadController.getInstance(account);
         }
         BillingController.getInstance().startConnection();
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/AutoDeleteMediaTask.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/AutoDeleteMediaTask.java
@@ -31,7 +31,7 @@ public class AutoDeleteMediaTask {
             }
             boolean hasExceptions = false;
             ArrayList<CacheByChatsController> cacheByChatsControllers = new ArrayList<>();
-            for (int account = 0; account < UserConfig.MAX_ACCOUNT_COUNT; account++) {
+            for (int account : UserConfig.getActivatedAccounts()) {
                 if (UserConfig.getInstance(account).isClientActivated()) {
                     CacheByChatsController cacheByChatsController = UserConfig.getInstance(account).getMessagesController().getCacheByChatsController();
                     cacheByChatsControllers.add(cacheByChatsController);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/BirthdayController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/BirthdayController.java
@@ -21,7 +21,7 @@ public class BirthdayController {
     private static volatile BirthdayController[] Instance = new BirthdayController[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ContactsController.java
@@ -108,7 +108,7 @@ public class ContactsController extends BaseController {
     private class MyContentObserver extends ContentObserver {
 
         private Runnable checkRunnable = () -> {
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 if (UserConfig.getInstance(a).isClientActivated()) {
                     ConnectionsManager.getInstance(a).resumeNetworkMaybe();
                     ContactsController.getInstance(a).checkContacts();
@@ -392,7 +392,7 @@ public class ContactsController extends BaseController {
                 for (int a = 0; a < accounts.length; a++) {
                     Account acc = accounts[a];
                     boolean found = false;
-                    for (int b = 0; b < UserConfig.MAX_ACCOUNT_COUNT; b++) {
+                    for (int b : UserConfig.getActivatedAccounts()) {
                         TLRPC.User user = UserConfig.getInstance(b).getCurrentUser();
                         if (user != null) {
                             if (acc.name.equals("" + user.id)) {
@@ -438,7 +438,7 @@ public class ContactsController extends BaseController {
             for (int a = 0; a < accounts.length; a++) {
                 Account acc = accounts[a];
                 boolean found = false;
-                for (int b = 0; b < UserConfig.MAX_ACCOUNT_COUNT; b++) {
+                for (int b : UserConfig.getActivatedAccounts()) {
                     TLRPC.User user = UserConfig.getInstance(b).getCurrentUser();
                     if (user != null) {
                         if (acc.name.equals("" + user.id)) {
@@ -514,7 +514,7 @@ public class ContactsController extends BaseController {
                         systemAccount = null;
                         for (int a = 0; a < accounts.length; a++) {
                             Account acc = accounts[a];
-                            for (int b = 0; b < UserConfig.MAX_ACCOUNT_COUNT; b++) {
+                            for (int b : UserConfig.getActivatedAccounts()) {
                                 TLRPC.User user = UserConfig.getInstance(b).getCurrentUser();
                                 if (user != null) {
                                     if (acc.name.equals("" + user.id)) {

--- a/TMessagesProj/src/main/java/org/telegram/messenger/FactCheckController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/FactCheckController.java
@@ -59,7 +59,7 @@ public class FactCheckController {
     private static volatile FactCheckController[] Instance = new FactCheckController[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/HashtagSearchController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/HashtagSearchController.java
@@ -20,7 +20,7 @@ public class HashtagSearchController {
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
 
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImageLoader.java
@@ -2161,7 +2161,7 @@ public class ImageLoader {
         AndroidUtilities.createEmptyFile(new File(cachePath, ".nomedia"));
         mediaDirs.put(FileLoader.MEDIA_DIR_CACHE, cachePath);
 
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             final int currentAccount = a;
             FileLoader.getInstance(a).setDelegate(new FileLoader.FileLoaderDelegate() {
                 @Override

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ImportingService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ImportingService.java
@@ -21,7 +21,7 @@ public class ImportingService extends Service implements NotificationCenter.Noti
 
     public ImportingService() {
         super();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.historyImportProgressChanged);
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.stickersImportProgressChanged);
         }
@@ -39,7 +39,7 @@ public class ImportingService extends Service implements NotificationCenter.Noti
 
         }
         NotificationManagerCompat.from(ApplicationLoader.applicationContext).cancel(5);
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.historyImportProgressChanged);
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.stickersImportProgressChanged);
         }
@@ -58,7 +58,7 @@ public class ImportingService extends Service implements NotificationCenter.Noti
     }
 
     private boolean hasImportingHistory() {
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             if (SendMessagesHelper.getInstance(a).isImportingHistory()) {
                 return true;
             }
@@ -67,7 +67,7 @@ public class ImportingService extends Service implements NotificationCenter.Noti
     }
 
     private boolean hasImportingStickers() {
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             if (SendMessagesHelper.getInstance(a).isImportingStickers()) {
                 return true;
             }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/LocaleController.java
@@ -3210,7 +3210,7 @@ public class LocaleController {
                     }
                 }, ConnectionsManager.RequestFlagWithoutLogin);
             } else {
-                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                for (int a : UserConfig.getActivatedAccounts()) {
                     ConnectionsManager.setLangCode(localeInfo.getLangCode());
                 }
                 FileLog.d("applyRemoteLanguage getLangPack");

--- a/TMessagesProj/src/main/java/org/telegram/messenger/LocationController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/LocationController.java
@@ -940,7 +940,7 @@ public class LocationController extends BaseController implements NotificationCe
 
     public static int getLocationsCount() {
         int count = 0;
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             count += LocationController.getInstance(a).sharingLocationsUI.size();
         }
         return count;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/LocationSharingService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/LocationSharingService.java
@@ -39,7 +39,7 @@ public class LocationSharingService extends Service implements NotificationCente
         runnable = () -> {
             handler.postDelayed(runnable, 1000);
             Utilities.stageQueue.postRunnable(() -> {
-                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                for (int a : UserConfig.getActivatedAccounts()) {
                     LocationController.getInstance(a).update();
                 }
             });
@@ -79,7 +79,7 @@ public class LocationSharingService extends Service implements NotificationCente
 
     private ArrayList<LocationController.SharingLocationInfo> getInfos() {
         ArrayList<LocationController.SharingLocationInfo> infos = new ArrayList<>();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             ArrayList<LocationController.SharingLocationInfo> arrayList = LocationController.getInstance(a).sharingLocationsUI;
             if (!arrayList.isEmpty()) {
                 infos.addAll(arrayList);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaController.java
@@ -1401,7 +1401,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
         fileBuffer = ByteBuffer.allocateDirect(1920);
 
         AndroidUtilities.runOnUIThread(() -> {
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 NotificationCenter.getInstance(a).addObserver(MediaController.this, NotificationCenter.fileLoaded);
                 NotificationCenter.getInstance(a).addObserver(MediaController.this, NotificationCenter.httpFileDidLoad);
                 NotificationCenter.getInstance(a).addObserver(MediaController.this, NotificationCenter.didReceiveNewMessages);
@@ -1585,7 +1585,7 @@ public class MediaController implements AudioManager.OnAudioFocusChangeListener,
         cleanupPlayer(true, true);
         audioInfo = null;
         playMusicAgain = false;
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             DownloadController.getInstance(a).cleanup();
         }
         videoConvertQueue.clear();

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
@@ -126,7 +126,7 @@ public class MediaDataController extends BaseController {
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
 
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MessagesStorage.java
@@ -105,7 +105,7 @@ public class MessagesStorage extends BaseController {
     private static volatile MessagesStorage[] Instance = new MessagesStorage[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MusicPlayerService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MusicPlayerService.java
@@ -91,7 +91,7 @@ public class MusicPlayerService extends Service implements NotificationCenter.No
     @Override
     public void onCreate() {
         audioManager = (AudioManager) getSystemService(AUDIO_SERVICE);
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.messagePlayingDidSeek);
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.messagePlayingPlayStateChanged);
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.httpFileDidLoad);
@@ -687,7 +687,7 @@ public class MusicPlayerService extends Service implements NotificationCenter.No
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             mediaSession.release();
         }
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.messagePlayingDidSeek);
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.messagePlayingPlayStateChanged);
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.httpFileDidLoad);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsController.java
@@ -176,7 +176,7 @@ public class NotificationsController extends BaseController {
     private static volatile NotificationsController[] Instance = new NotificationsController[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }
@@ -1666,7 +1666,7 @@ public class NotificationsController extends BaseController {
 
     private int getTotalAllUnreadCount() {
         int count = 0;
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             if (!UserConfig.getInstance(a).isClientActivated() || !SharedConfig.showNotificationsForAllAccounts && UserConfig.selectedAccount != a) {
                 continue;
             }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ProxyRotationController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ProxyRotationController.java
@@ -92,7 +92,7 @@ public class ProxyRotationController implements NotificationCenter.NotificationC
     }
 
     private void initInternal() {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(i).addObserver(this, NotificationCenter.didUpdateConnectionState);
         }
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.proxyCheckDone);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/PushListenerController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/PushListenerController.java
@@ -60,7 +60,7 @@ public class PushListenerController {
             }
             SharedConfig.pushString = token;
             SharedConfig.pushType = pushType;
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 UserConfig userConfig = UserConfig.getInstance(a);
                 userConfig.registeredForPush = false;
                 userConfig.saveConfig(false);
@@ -200,7 +200,7 @@ public class PushListenerController {
                     }
                     int account = UserConfig.selectedAccount;
                     boolean foundAccount = false;
-                    for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                    for (int a : UserConfig.getActivatedAccounts()) {
                         if (UserConfig.getInstance(a).getClientUserId() == accountUserId) {
                             account = a;
                             foundAccount = true;
@@ -1583,7 +1583,7 @@ public class PushListenerController {
     }
 
     private static void onDecryptError() {
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             if (UserConfig.getInstance(a).isClientActivated()) {
                 ConnectionsManager.onInternalPushReceived(a);
                 ConnectionsManager.getInstance(a).resumeNetworkMaybe();

--- a/TMessagesProj/src/main/java/org/telegram/messenger/StopLiveLocationReceiver.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/StopLiveLocationReceiver.java
@@ -16,7 +16,7 @@ public class StopLiveLocationReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             LocationController.getInstance(a).removeAllLocationSharings();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/UserConfig.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/UserConfig.java
@@ -11,6 +11,7 @@ package org.telegram.messenger;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.SystemClock;
+import android.text.TextUtils;
 import android.util.Base64;
 import android.util.LongSparseArray;
 
@@ -19,13 +20,18 @@ import org.telegram.tgnet.SerializedData;
 import org.telegram.tgnet.TLRPC;
 import org.telegram.tgnet.tl.TL_account;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class UserConfig extends BaseController {
 
     public static int selectedAccount;
     public final static int MAX_ACCOUNT_DEFAULT_COUNT = 3;
     public final static int MAX_ACCOUNT_COUNT = 4;
+
+    private static final ArrayList<Integer> activatedAccounts = new ArrayList<>();
+    private static final ArrayList<Integer> pendingAccounts = new ArrayList<>();
 
     private final Object sync = new Object();
     private volatile boolean configLoaded;
@@ -96,14 +102,89 @@ public class UserConfig extends BaseController {
         return localInstance;
     }
 
-    public static int getActivatedAccountsCount() {
-        int count = 0;
-        for (int a = 0; a < MAX_ACCOUNT_COUNT; a++) {
-            if (AccountInstance.getInstance(a).getUserConfig().isClientActivated()) {
-                count++;
+    private static void loadGlobalAccounts() {
+        if (!activatedAccounts.isEmpty() || !pendingAccounts.isEmpty()) {
+            return;
+        }
+        if (ApplicationLoader.applicationContext == null) {
+            if (activatedAccounts.isEmpty()) {
+                activatedAccounts.add(selectedAccount);
+            }
+            return;
+        }
+        SharedPreferences prefs = ApplicationLoader.applicationContext.getSharedPreferences("userconfig_global", Context.MODE_PRIVATE);
+        String act = prefs.getString("activatedAccounts", null);
+        if (act != null && act.length() > 0) {
+            for (String s : act.split(",")) {
+                try {
+                    activatedAccounts.add(Integer.parseInt(s));
+                } catch (Exception ignore) {
+                }
             }
         }
-        return count;
+        if (activatedAccounts.isEmpty()) {
+            activatedAccounts.add(selectedAccount);
+        }
+        String pend = prefs.getString("pendingAccounts", null);
+        if (pend != null && pend.length() > 0) {
+            for (String s : pend.split(",")) {
+                try {
+                    pendingAccounts.add(Integer.parseInt(s));
+                } catch (Exception ignore) {
+                }
+            }
+        }
+    }
+
+    private static void saveGlobalAccounts() {
+        SharedPreferences prefs = ApplicationLoader.applicationContext.getSharedPreferences("userconfig_global", Context.MODE_PRIVATE);
+        prefs.edit()
+                .putString("activatedAccounts", TextUtils.join(",", activatedAccounts))
+                .putString("pendingAccounts", TextUtils.join(",", pendingAccounts))
+                .apply();
+    }
+
+    public static List<Integer> getActivatedAccounts() {
+        loadGlobalAccounts();
+        return new ArrayList<>(activatedAccounts);
+    }
+
+    public static int getActivatedAccountsCount() {
+        loadGlobalAccounts();
+        return activatedAccounts.size();
+    }
+
+    public static int getPendingAccountsCount() {
+        loadGlobalAccounts();
+        return pendingAccounts.size();
+    }
+
+    public static int requestAccountSlot() {
+        loadGlobalAccounts();
+        for (int a = 0; a < MAX_ACCOUNT_COUNT; a++) {
+            if (!activatedAccounts.contains(a) && !pendingAccounts.contains(a)) {
+                pendingAccounts.add(a);
+                saveGlobalAccounts();
+                return a;
+            }
+        }
+        return -1;
+    }
+
+    public static void activateAccount(int account) {
+        loadGlobalAccounts();
+        pendingAccounts.remove((Integer) account);
+        if (!activatedAccounts.contains(account)) {
+            activatedAccounts.add(account);
+        }
+        saveGlobalAccounts();
+    }
+
+    public static void deactivateAccount(int account) {
+        loadGlobalAccounts();
+        activatedAccounts.remove((Integer) account);
+        pendingAccounts.remove((Integer) account);
+        saveGlobalAccounts();
     }
 
     public UserConfig(int instance) {
@@ -111,7 +192,7 @@ public class UserConfig extends BaseController {
     }
 
     public static boolean hasPremiumOnAccounts() {
-        for (int a = 0; a < MAX_ACCOUNT_COUNT; a++) {
+        for (int a : getActivatedAccounts()) {
             if (AccountInstance.getInstance(a).getUserConfig().isClientActivated() && AccountInstance.getInstance(a).getUserConfig().getUserConfig().isPremium()) {
                 return true;
             }
@@ -487,14 +568,8 @@ public class UserConfig extends BaseController {
         lastContactsSyncTime = (int) (System.currentTimeMillis() / 1000) - 23 * 60 * 60;
         lastHintsSyncTime = (int) (System.currentTimeMillis() / 1000) - 25 * 60 * 60;
         resetSavedPassword();
-        boolean hasActivated = false;
-        for (int a = 0; a < MAX_ACCOUNT_COUNT; a++) {
-            if (AccountInstance.getInstance(a).getUserConfig().isClientActivated()) {
-                hasActivated = true;
-                break;
-            }
-        }
-        if (!hasActivated) {
+        deactivateAccount(currentAccount);
+        if (getActivatedAccounts().isEmpty()) {
             SharedConfig.clearConfig();
         }
         saveConfig(true);
@@ -604,10 +679,16 @@ public class UserConfig extends BaseController {
     }
 
     public static int getProductionAccount() {
-        for (int i = -1; i < MAX_ACCOUNT_COUNT; ++i) {
-            final int account = i < 0 ? selectedAccount : i;
-            if (getInstance(account).isClientActivated() && !ConnectionsManager.getInstance(account).isTestBackend())
+        if (getInstance(selectedAccount).isClientActivated() && !ConnectionsManager.getInstance(selectedAccount).isTestBackend()) {
+            return selectedAccount;
+        }
+        for (int account : getActivatedAccounts()) {
+            if (account == selectedAccount) {
+                continue;
+            }
+            if (getInstance(account).isClientActivated() && !ConnectionsManager.getInstance(account).isTestBackend()) {
                 return account;
+            }
         }
         return selectedAccount;
     }

--- a/TMessagesProj/src/main/java/org/telegram/messenger/utils/BillingUtilities.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/utils/BillingUtilities.java
@@ -210,7 +210,7 @@ public class BillingUtilities {
 
     private static AccountInstance findAccountById(long accountId) {
         AccountInstance result = null;
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             AccountInstance acc = AccountInstance.getInstance(i);
             if (acc.getUserConfig().getClientUserId() == accountId) {
                 result = acc;

--- a/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/voip/VoIPPreNotificationService.java
@@ -614,7 +614,7 @@ public class VoIPPreNotificationService { // } extends Service implements AudioM
         nm.cancel(VoIPService.ID_INCOMING_CALL_PRENOTIFICATION);
         stopRinging();
         if (!answered) {
-            for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+            for (int i : UserConfig.getActivatedAccounts()) {
                 MessagesController.getInstance(i).ignoreSetOnline = false;
             }
         }

--- a/TMessagesProj/src/main/java/org/telegram/tgnet/ConnectionsManager.java
+++ b/TMessagesProj/src/main/java/org/telegram/tgnet/ConnectionsManager.java
@@ -628,7 +628,7 @@ public class ConnectionsManager extends BaseController {
 
     public static void setLangCode(String langCode) {
         langCode = langCode.replace('_', '-').toLowerCase();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             native_setLangCode(a, langCode);
         }
     }
@@ -645,14 +645,14 @@ public class ConnectionsManager extends BaseController {
             String tag = type == PushListenerController.PUSH_TYPE_FIREBASE ? "FIREBASE" : "HUAWEI";
             pushString = SharedConfig.pushStringStatus = "__" + tag + "_GENERATING_SINCE_" + getInstance(0).getCurrentTime() + "__";
         }
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             native_setRegId(a, pushString);
         }
     }
 
     public static void setSystemLangCode(String langCode) {
         langCode = langCode.replace('_', '-').toLowerCase();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             native_setSystemLangCode(a, langCode);
         }
     }
@@ -911,7 +911,7 @@ public class ConnectionsManager extends BaseController {
             secret = "";
         }
 
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             if (enabled && !TextUtils.isEmpty(address)) {
                 native_setProxySettings(a, address, port, username, password, secret);
             } else {

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/Theme.java
@@ -4705,7 +4705,7 @@ public class Theme {
         int remoteVersion = themeConfig.getInt("remote_version", 0);
         int appRemoteThemesVersion = 1;
         if (remoteVersion == appRemoteThemesVersion) {
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 remoteThemesHash[a] = themeConfig.getLong("2remoteThemesHash" + (a != 0 ? a : ""), 0);
                 lastLoadingThemesTime[a] = themeConfig.getInt("lastLoadingThemesTime" + (a != 0 ? a : ""), 0);
             }
@@ -6971,7 +6971,7 @@ public class Theme {
             }
             editor.putString("themes2", array.toString());
         }
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             editor.putLong("2remoteThemesHash" + (a != 0 ? a : ""), remoteThemesHash[a]);
             editor.putInt("lastLoadingThemesTime" + (a != 0 ? a : ""), lastLoadingThemesTime[a]);
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DrawerLayoutAdapter.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Adapters/DrawerLayoutAdapter.java
@@ -228,7 +228,7 @@ public class DrawerLayoutAdapter extends RecyclerListView.SelectionAdapter {
 
     private void resetItems() {
         accountNumbers.clear();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             if (UserConfig.getInstance(a).isClientActivated()) {
                 accountNumbers.add(a);
             }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Business/BusinessChatbotController.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Business/BusinessChatbotController.java
@@ -14,7 +14,7 @@ public class BusinessChatbotController {
     private static volatile BusinessChatbotController[] Instance = new BusinessChatbotController[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Business/BusinessLinksController.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Business/BusinessLinksController.java
@@ -28,7 +28,7 @@ public class BusinessLinksController {
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
 
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Business/QuickRepliesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Business/QuickRepliesController.java
@@ -36,7 +36,7 @@ public class QuickRepliesController {
     private static volatile QuickRepliesController[] Instance = new QuickRepliesController[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Business/TimezonesController.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Business/TimezonesController.java
@@ -25,7 +25,7 @@ public class TimezonesController {
     private static volatile TimezonesController[] Instance = new TimezonesController[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/CacheControlActivity.java
@@ -647,7 +647,7 @@ public class CacheControlActivity extends BaseFragment implements NotificationCe
                     cacheModel.add(addToType, fileInfo);
                 }
                 //TODO measure for other accounts
-//                for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+//                for (int i : UserConfig.getActivatedAccounts()) {
 //                    if (i != currentAccount && UserConfig.getInstance(currentAccount).isClientActivated()) {
 //                        FileLoader.getInstance(currentAccount).getFileDatabase().getFileDialogId(fileEntry);
 //                    }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DrawerProfileCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DrawerProfileCell.java
@@ -478,7 +478,7 @@ public class DrawerProfileCell extends FrameLayout implements NotificationCenter
         status.attach();
         updateColors();
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.emojiLoaded);
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++){
+        for (int i : UserConfig.getActivatedAccounts()){
             NotificationCenter.getInstance(i).addObserver(this, NotificationCenter.currentUserPremiumStatusChanged);
         }
     }
@@ -488,7 +488,7 @@ public class DrawerProfileCell extends FrameLayout implements NotificationCenter
         super.onDetachedFromWindow();
         status.detach();
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.emojiLoaded);
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++){
+        for (int i : UserConfig.getActivatedAccounts()){
             NotificationCenter.getInstance(i).removeObserver(this, NotificationCenter.currentUserPremiumStatusChanged);
         }
         if (lastAccount >= 0) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/DrawerUserCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/DrawerUserCell.java
@@ -96,7 +96,7 @@ public class DrawerUserCell extends FrameLayout implements NotificationCenter.No
         textView.setTextColor(Theme.getColor(Theme.key_chats_menuItemText));
         status.attach();
         botVerification.attach();
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++){
+        for (int i : UserConfig.getActivatedAccounts()){
             NotificationCenter.getInstance(i).addObserver(this, NotificationCenter.currentUserPremiumStatusChanged);
             NotificationCenter.getInstance(i).addObserver(this, NotificationCenter.updateInterfaces);
         }
@@ -108,7 +108,7 @@ public class DrawerUserCell extends FrameLayout implements NotificationCenter.No
         super.onDetachedFromWindow();
         status.detach();
         botVerification.detach();
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++){
+        for (int i : UserConfig.getActivatedAccounts()){
             NotificationCenter.getInstance(i).removeObserver(this, NotificationCenter.currentUserPremiumStatusChanged);
             NotificationCenter.getInstance(i).removeObserver(this, NotificationCenter.updateInterfaces);
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/ThemesHorizontalListCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/ThemesHorizontalListCell.java
@@ -811,7 +811,7 @@ public class ThemesHorizontalListCell extends RecyclerListView implements Notifi
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.fileLoaded);
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.fileLoadFailed);
         }
@@ -820,7 +820,7 @@ public class ThemesHorizontalListCell extends RecyclerListView implements Notifi
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.fileLoaded);
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.fileLoadFailed);
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/AlertsCreator.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/AlertsCreator.java
@@ -6422,7 +6422,7 @@ public class AlertsCreator {
 
         final LinearLayout linearLayout = new LinearLayout(parentActivity);
         linearLayout.setOrientation(LinearLayout.VERTICAL);
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             TLRPC.User u = UserConfig.getInstance(a).getCurrentUser();
             if (u != null) {
                 AccountSelectCell cell = new AccountSelectCell(parentActivity, false);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/FragmentContextView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/FragmentContextView.java
@@ -708,7 +708,7 @@ public class FragmentContextView extends FrameLayout implements NotificationCent
                 }
                 builder.setPositiveButton(getString(R.string.Stop), (dialogInterface, i) -> {
                     if (fragment instanceof DialogsActivity) {
-                        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                        for (int a : UserConfig.getActivatedAccounts()) {
                             LocationController.getInstance(a).removeAllLocationSharings();
                         }
                     } else {
@@ -767,7 +767,7 @@ public class FragmentContextView extends FrameLayout implements NotificationCent
                     did = chatActivity.getDialogId();
                     account = fragment.getCurrentAccount();
                 } else if (LocationController.getLocationsCount() == 1) {
-                    for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                    for (int a : UserConfig.getActivatedAccounts()) {
                         ArrayList<LocationController.SharingLocationInfo> arrayList = LocationController.getInstance(a).sharingLocationsUI;
                         if (!arrayList.isEmpty()) {
                             LocationController.SharingLocationInfo info = LocationController.getInstance(a).sharingLocationsUI.get(0);
@@ -1301,7 +1301,7 @@ public class FragmentContextView extends FrameLayout implements NotificationCent
             NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.liveLocationsChanged);
             NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.liveLocationsCacheChanged);
         } else {
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.messagePlayingDidReset);
                 NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.messagePlayingPlayStateChanged);
                 NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.messagePlayingDidStart);
@@ -1337,7 +1337,7 @@ public class FragmentContextView extends FrameLayout implements NotificationCent
             }
             checkLiveLocation(true);
         } else {
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.messagePlayingDidReset);
                 NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.messagePlayingPlayStateChanged);
                 NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.messagePlayingDidStart);
@@ -1573,7 +1573,7 @@ public class FragmentContextView extends FrameLayout implements NotificationCent
                 String param;
                 String str;
                 ArrayList<LocationController.SharingLocationInfo> infos = new ArrayList<>();
-                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                for (int a : UserConfig.getActivatedAccounts()) {
                     infos.addAll(LocationController.getInstance(a).sharingLocationsUI);
                 }
                 if (infos.size() == 1) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/SharingLocationsAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/SharingLocationsAlert.java
@@ -181,7 +181,7 @@ public class SharingLocationsAlert extends BottomSheet implements NotificationCe
         pickerBottomLayout.cancelButton.setTextColor(getThemedColor(Theme.key_text_RedBold));
         pickerBottomLayout.cancelButton.setText(LocaleController.getString(R.string.StopAllLocationSharings));
         pickerBottomLayout.cancelButton.setOnClickListener(view -> {
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 LocationController.getInstance(a).removeAllLocationSharings();
             }
             dismiss();
@@ -229,7 +229,7 @@ public class SharingLocationsAlert extends BottomSheet implements NotificationCe
     }
 
     private LocationController.SharingLocationInfo getLocation(int position) {
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             ArrayList<LocationController.SharingLocationInfo> infos = LocationController.getInstance(a).sharingLocationsUI;
             if (position >= infos.size()) {
                 position -= infos.size();

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -3659,7 +3659,7 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
             Drawable thumb = user != null && user.photo != null && user.photo.strippedBitmap != null ? user.photo.strippedBitmap : avatarDrawable;
             imageView.setImage(ImageLocation.getForUserOrChat(user, ImageLocation.TYPE_SMALL), "50_50", ImageLocation.getForUserOrChat(user, ImageLocation.TYPE_STRIPPED), "50_50", thumb, user);
 
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 TLRPC.User u = AccountInstance.getInstance(a).getUserConfig().getCurrentUser();
                 if (u != null) {
                     AccountSelectCell cell = new AccountSelectCell(context, false);

--- a/TMessagesProj/src/main/java/org/telegram/ui/LanguageSelectActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LanguageSelectActivity.java
@@ -280,7 +280,7 @@ public class LanguageSelectActivity extends BaseFragment implements Notification
 //                                            }
 //                                        }
 //                                        if (languages2.isEmpty()) return;
-//                                        for (int account = 0; account < UserConfig.MAX_ACCOUNT_COUNT; ++account) {
+//                                        for (int account : UserConfig.getActivatedAccounts()) {
 //                                            MessagesController.getInstance(account).getTranslateController().clearDownloadingModels();
 //                                        }
 //                                        BaseFragment lastFragment = LaunchActivity.getSafeLastFragment();

--- a/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LaunchActivity.java
@@ -588,21 +588,9 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                 switchToAccount(((DrawerUserCell) view).getAccountNumber(), true);
                 drawerLayoutContainer.closeDrawer(false);
             } else if (view instanceof DrawerAddCell) {
-                int freeAccounts = 0;
-                Integer availableAccount = null;
-                for (int a = UserConfig.MAX_ACCOUNT_COUNT - 1; a >= 0; a--) {
-                    if (!UserConfig.getInstance(a).isClientActivated()) {
-                        freeAccounts++;
-                        if (availableAccount == null) {
-                            availableAccount = a;
-                        }
-                    }
-                }
-                if (!UserConfig.hasPremiumOnAccounts()) {
-                    freeAccounts -= (UserConfig.MAX_ACCOUNT_COUNT - UserConfig.MAX_ACCOUNT_DEFAULT_COUNT);
-                }
-                if (freeAccounts > 0 && availableAccount != null) {
-                    presentFragment(new LoginActivity(availableAccount));
+                int slot = UserConfig.requestAccountSlot();
+                if (slot >= 0) {
+                    presentFragment(new LoginActivity(slot));
                     drawerLayoutContainer.closeDrawer(false);
                 } else if (!UserConfig.hasPremiumOnAccounts()) {
                     if (actionBarLayout.getFragmentStack().size() > 0) {
@@ -1530,7 +1518,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
 
     private void switchToAvailableAccountOrLogout() {
         int account = -1;
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             if (UserConfig.getInstance(a).isClientActivated()) {
                 account = a;
                 break;
@@ -3037,12 +3025,20 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                                         if (cursor.moveToFirst()) {
                                             long userId = cursor.getLong(cursor.getColumnIndex(ContactsContract.Data.DATA4));
                                             int accountId = Utilities.parseInt(cursor.getString(cursor.getColumnIndex(ContactsContract.RawContacts.ACCOUNT_NAME)));
-                                            for (int a = -1; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
-                                                int i = a == -1 ? intentAccount[0] : a;
-                                                if ((a == -1 && MessagesStorage.getInstance(i).containsLocalDialog(userId)) || UserConfig.getInstance(i).getClientUserId() == accountId) {
-                                                    intentAccount[0] = i;
-                                                    switchToAccount(intentAccount[0], true);
-                                                    break;
+                                            int current = intentAccount[0];
+                                            if (MessagesStorage.getInstance(current).containsLocalDialog(userId) || UserConfig.getInstance(current).getClientUserId() == accountId) {
+                                                intentAccount[0] = current;
+                                                switchToAccount(intentAccount[0], true);
+                                            } else {
+                                                for (int i : UserConfig.getActivatedAccounts()) {
+                                                    if (i == current) {
+                                                        continue;
+                                                    }
+                                                    if (MessagesStorage.getInstance(i).containsLocalDialog(userId) || UserConfig.getInstance(i).getClientUserId() == accountId) {
+                                                        intentAccount[0] = i;
+                                                        switchToAccount(intentAccount[0], true);
+                                                        break;
+                                                    }
                                                 }
                                             }
                                             NotificationCenter.getInstance(intentAccount[0]).postNotificationName(NotificationCenter.closeChats);
@@ -8412,7 +8408,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                 drawerLayoutContainer.setAllowOpenDrawer(false, true);
 
                 int account = -1;
-                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                for (int a : UserConfig.getActivatedAccounts()) {
                     if (UserConfig.getInstance(a).isClientActivated()) {
                         account = a;
                         break;
@@ -8495,7 +8491,7 @@ public class LaunchActivity extends BasePermissionsActivity implements INavigati
                 drawerLayoutContainer.setAllowOpenDrawer(false, true);
 
                 int account = -1;
-                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                for (int a : UserConfig.getActivatedAccounts()) {
                     if (UserConfig.getInstance(a).isClientActivated()) {
                         account = a;
                         break;

--- a/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LoginActivity.java
@@ -1648,6 +1648,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
         clearCurrentState();
         if (getParentActivity() instanceof LaunchActivity) {
             if (newAccount) {
+                UserConfig.activateAccount(currentAccount);
                 newAccount = false;
                 pendingSwitchingAccount = true;
                 ((LaunchActivity) getParentActivity()).switchToAccount(currentAccount, false, obj -> {
@@ -3038,7 +3039,7 @@ public class LoginActivity extends BaseFragment implements NotificationCenter.No
             String phone = PhoneFormat.stripExceptNumbers("" + codeField.getText() + phoneField.getText());
             if (activityMode == MODE_LOGIN) {
                 if (getParentActivity() instanceof LaunchActivity) {
-                    for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                    for (int a : UserConfig.getActivatedAccounts()) {
                         UserConfig userConfig = UserConfig.getInstance(a);
                         if (!userConfig.isClientActivated()) {
                             continue;

--- a/TMessagesProj/src/main/java/org/telegram/ui/LogoutActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/LogoutActivity.java
@@ -70,7 +70,7 @@ public class LogoutActivity extends BaseFragment {
 
         rowCount = 0;
         alternativeHeaderRow = rowCount++;
-        if (UserConfig.getActivatedAccountsCount() < UserConfig.MAX_ACCOUNT_COUNT) {
+        if (UserConfig.getActivatedAccountsCount() + UserConfig.getPendingAccountsCount() < UserConfig.getMaxAccountCount()) {
             addAccountRow = rowCount++;
         } else {
             addAccountRow = -1;
@@ -120,21 +120,9 @@ public class LogoutActivity extends BaseFragment {
         listView.setAdapter(listAdapter);
         listView.setOnItemClickListener((view, position, x, y) -> {
             if (position == addAccountRow) {
-                int freeAccounts = 0;
-                Integer availableAccount = null;
-                for (int a = UserConfig.MAX_ACCOUNT_COUNT - 1; a >= 0; a--) {
-                    if (!UserConfig.getInstance(a).isClientActivated()) {
-                        freeAccounts++;
-                        if (availableAccount == null) {
-                            availableAccount = a;
-                        }
-                    }
-                }
-                if (!UserConfig.hasPremiumOnAccounts()) {
-                    freeAccounts -= (UserConfig.MAX_ACCOUNT_COUNT - UserConfig.MAX_ACCOUNT_DEFAULT_COUNT);
-                }
-                if (freeAccounts > 0 && availableAccount != null) {
-                    presentFragment(new LoginActivity(availableAccount));
+                int slot = UserConfig.requestAccountSlot();
+                if (slot != -1) {
+                    presentFragment(new LoginActivity(slot));
                 } else if (!UserConfig.hasPremiumOnAccounts()) {
                     LimitReachedBottomSheet limitReachedBottomSheet = new LimitReachedBottomSheet(this, getContext(), TYPE_ACCOUNTS, currentAccount, null);
                     showDialog(limitReachedBottomSheet);

--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationPermissionDialog.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationPermissionDialog.java
@@ -110,7 +110,7 @@ public class NotificationPermissionDialog extends BottomSheet implements Notific
         });
         linearLayout.addView(textView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 48, 14, 14, 14, 10));
 
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; ++a) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             try {
                 NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.updateInterfaces);
             } catch (Exception ignore) {}
@@ -129,7 +129,7 @@ public class NotificationPermissionDialog extends BottomSheet implements Notific
 
     public void updateCounter() {
         int counter = 0;
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; ++a) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             MessagesStorage messagesStorage = MessagesStorage.getInstance(a);
             if (messagesStorage != null) {
                 counter += messagesStorage.getMainUnreadCount();
@@ -159,7 +159,7 @@ public class NotificationPermissionDialog extends BottomSheet implements Notific
             whenGranted = null;
             askLater();
         }
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; ++a) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             try {
                 NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.updateInterfaces);
             } catch (Exception ignore) {}

--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
@@ -694,7 +694,7 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                 editor.putBoolean("AllAccounts", !enabled);
                 editor.commit();
                 SharedConfig.showNotificationsForAllAccounts = !enabled;
-                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                for (int a : UserConfig.getActivatedAccounts()) {
                     if (SharedConfig.showNotificationsForAllAccounts) {
                         NotificationsController.getInstance(a).showNotifications();
                     } else {

--- a/TMessagesProj/src/main/java/org/telegram/ui/PopupNotificationActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/PopupNotificationActivity.java
@@ -163,7 +163,7 @@ public class PopupNotificationActivity extends Activity implements NotificationC
         Theme.createChatResources(this, false);
 
         AndroidUtilities.fillStatusBarHeight(this, false);
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.appDidLogout);
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.updateInterfaces);
             NotificationCenter.getInstance(a).addObserver(this, NotificationCenter.messagePlayingProgressDidChanged);
@@ -1197,7 +1197,7 @@ public class PopupNotificationActivity extends Activity implements NotificationC
             }
             popupMessages.addAll(NotificationsController.getInstance(account).popupReplyMessages);
         } else {
-            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+            for (int a : UserConfig.getActivatedAccounts()) {
                 if (UserConfig.getInstance(a).isClientActivated()) {
                     popupMessages.addAll(NotificationsController.getInstance(a).popupMessages);
                 }
@@ -1467,7 +1467,7 @@ public class PopupNotificationActivity extends Activity implements NotificationC
         } else if (id == NotificationCenter.pushMessagesUpdated) {
             if (!isReply) {
                 popupMessages.clear();
-                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                for (int a : UserConfig.getActivatedAccounts()) {
                     if (UserConfig.getInstance(a).isClientActivated()) {
                         popupMessages.addAll(NotificationsController.getInstance(a).popupMessages);
                     }
@@ -1583,7 +1583,7 @@ public class PopupNotificationActivity extends Activity implements NotificationC
         if (isReply) {
             popupMessages.clear();
         }
-        for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+        for (int a : UserConfig.getActivatedAccounts()) {
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.appDidLogout);
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.updateInterfaces);
             NotificationCenter.getInstance(a).removeObserver(this, NotificationCenter.messagePlayingProgressDidChanged);

--- a/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ProfileActivity.java
@@ -12853,7 +12853,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                 new SearchResult(501, getString(R.string.ChangePhoneNumber), 0, () -> presentFragment(new ActionIntroActivity(ActionIntroActivity.ACTION_TYPE_CHANGE_PHONE_NUMBER))),
                 new SearchResult(502, getString(R.string.AddAnotherAccount), 0, () -> {
                     int freeAccount = -1;
-                    for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                    for (int a : UserConfig.getActivatedAccounts()) {
                         if (!UserConfig.getInstance(a).isClientActivated()) {
                             freeAccount = a;
                             break;
@@ -13399,7 +13399,7 @@ public class ProfileActivity extends BaseFragment implements NotificationCenter.
                         if (stringBuilder != null && i == searchArgs.length - 1) {
                             if (result.guid == 502) {
                                 int freeAccount = -1;
-                                for (int b = 0; b < UserConfig.MAX_ACCOUNT_COUNT; b++) {
+                                for (int b : UserConfig.getActivatedAccounts()) {
                                     if (!UserConfig.getInstance(b).isClientActivated()) {
                                         freeAccount = b;
                                         break;

--- a/TMessagesProj/src/main/java/org/telegram/ui/RestrictedLanguagesSelectActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/RestrictedLanguagesSelectActivity.java
@@ -555,7 +555,7 @@ public class RestrictedLanguagesSelectActivity extends BaseFragment implements N
                 edit.putInt("translate_button_restricted_languages_version", LAST_DO_NOT_TRANSLATE_VERSION).apply();
                 invalidateRestrictedLanguages();
 
-                for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+                for (int i : UserConfig.getActivatedAccounts()) {
                     final int account = i;
                     try {
                         MessagesController.getInstance(account).getTranslateController().checkRestrictedLanguagesUpdate();

--- a/TMessagesProj/src/main/java/org/telegram/ui/SessionsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SessionsActivity.java
@@ -313,7 +313,7 @@ public class SessionsActivity extends BaseFragment implements NotificationCenter
                                 }
                             });
 
-                            for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                            for (int a : UserConfig.getActivatedAccounts()) {
                                 UserConfig userConfig = UserConfig.getInstance(a);
                                 if (!userConfig.isClientActivated()) {
                                     continue;

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stars/BotStarsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stars/BotStarsController.java
@@ -33,7 +33,7 @@ public class BotStarsController {
     private static volatile BotStarsController[] Instance = new BotStarsController[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stars/StarsController.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stars/StarsController.java
@@ -99,7 +99,7 @@ public class StarsController {
     private static final Object[][] lockObjects = new Object[2][UserConfig.MAX_ACCOUNT_COUNT];
     static {
         for (int a = 0; a < 2; ++a) {
-            for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+            for (int i : UserConfig.getActivatedAccounts()) {
                 lockObjects[a][i] = new Object();
             }
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/BotBiometry.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/BotBiometry.java
@@ -496,7 +496,7 @@ public class BotBiometry {
     public static void clear() {
         Context context = ApplicationLoader.applicationContext;
         if (context == null) return;
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             final SharedPreferences prefs = context.getSharedPreferences(PREF + i, Activity.MODE_PRIVATE);
             prefs.edit().clear().apply();
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/BotDownloads.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/BotDownloads.java
@@ -883,7 +883,7 @@ public class BotDownloads {
     public static void clear() {
         Context context = ApplicationLoader.applicationContext;
         if (context == null) return;
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             final SharedPreferences prefs = context.getSharedPreferences(PREF + i, Activity.MODE_PRIVATE);
             prefs.edit().clear().apply();
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/BotLocation.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/BotLocation.java
@@ -558,7 +558,7 @@ public class BotLocation {
     public static void clear() {
         Context context = ApplicationLoader.applicationContext;
         if (context == null) return;
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             final SharedPreferences prefs = context.getSharedPreferences(PREF + i, Activity.MODE_PRIVATE);
             prefs.edit().clear().apply();
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/BotStorage.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/BotStorage.java
@@ -301,7 +301,7 @@ public class BotStorage {
         boolean can_restore = false;
         if (secured && value == null && !thisJSON.keys().hasNext()) {
             final HashSet<Long> activeUsers = new HashSet<>();
-            for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+            for (int i : UserConfig.getActivatedAccounts()) {
                 final UserConfig userConfig = UserConfig.getInstance(i);
                 if (userConfig.isClientActivated()) {
                     activeUsers.add(userConfig.getClientUserId());
@@ -341,7 +341,7 @@ public class BotStorage {
         final ArrayList<StorageConfig> result = new ArrayList<>();
 
         final HashSet<Long> activeUsers = new HashSet<>();
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             final UserConfig userConfig = UserConfig.getInstance(i);
             if (userConfig.isClientActivated()) {
                 activeUsers.add(userConfig.getClientUserId());
@@ -378,7 +378,7 @@ public class BotStorage {
         }
 
         final HashSet<Long> activeUsers = new HashSet<>();
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             final UserConfig userConfig = UserConfig.getInstance(i);
             if (userConfig.isClientActivated()) {
                 activeUsers.add(userConfig.getClientUserId());

--- a/TMessagesProj/src/main/java/org/telegram/ui/bots/SetupEmojiStatusSheet.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/bots/SetupEmojiStatusSheet.java
@@ -499,7 +499,7 @@ public class SetupEmojiStatusSheet {
     public static void clear() {
         Context context = ApplicationLoader.applicationContext;
         if (context == null) return;
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             final SharedPreferences prefs = context.getSharedPreferences(PREF + i, Activity.MODE_PRIVATE);
             prefs.edit().clear().apply();
         }

--- a/TMessagesProj_AppStandalone/src/main/java/org/telegram/messenger/SMSJobController.java
+++ b/TMessagesProj_AppStandalone/src/main/java/org/telegram/messenger/SMSJobController.java
@@ -56,11 +56,14 @@ public class SMSJobController implements NotificationCenter.NotificationCenterDe
     private static volatile SMSJobController[] Instance = new SMSJobController[UserConfig.MAX_ACCOUNT_COUNT];
     private static final Object[] lockObjects = new Object[UserConfig.MAX_ACCOUNT_COUNT];
     static {
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; i++) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             lockObjects[i] = new Object();
         }
     }
     public static SMSJobController getInstance(int num) {
+        if (lockObjects[num] == null) {
+            lockObjects[num] = new Object();
+        }
         SMSJobController localInstance = Instance[num];
         if (localInstance == null) {
             synchronized (lockObjects[num]) {

--- a/TMessagesProj_AppStandalone/src/main/java/org/telegram/messenger/SMSJobsNotification.java
+++ b/TMessagesProj_AppStandalone/src/main/java/org/telegram/messenger/SMSJobsNotification.java
@@ -31,7 +31,7 @@ public class SMSJobsNotification extends Service {
 
     public static boolean check() {
         boolean shown = false;
-        for (int i = 0; i < UserConfig.MAX_ACCOUNT_COUNT; ++i) {
+        for (int i : UserConfig.getActivatedAccounts()) {
             shown = check(i) || shown;
         }
         return shown;


### PR DESCRIPTION
## Summary
- iterate over activated accounts instead of fixed slot count across client
- allocate account slots on demand and adjust add-account flow
- guard global account loading before application context is ready
- restore MessagesController without unintended large diff
- restrict push registration/unregistration and logout account selection to activated profiles
- revert MessagesController file to match master and retain MAX_ACCOUNT_COUNT loops

## Testing
- Tests were not run

------
https://chatgpt.com/codex/tasks/task_e_68ac74259428832caa9135a965b467b1